### PR TITLE
Correct Comment and Sharp token filtering

### DIFF
--- a/test/Test.hx
+++ b/test/Test.hx
@@ -3,6 +3,9 @@ class Test extends haxe.unit.TestCase {
 	static var whitespaceEreg = ~/[\t\n\r]*/g;
 	
 	static function main() {
+		//workaround for haxe issue #2902
+		var p:hxparse.Parser<hxparse.TokenSource.LexerTokenSource<haxeparser.Data.Token>, haxeparser.Data.Token>;
+
 		var r = new haxe.unit.TestRunner();
 		r.add(new Test());
 		#if haxe_std_path


### PR DESCRIPTION
This depends on Simn/hxparse#19 and suffers from HaxeFoundation/haxe#2902

Filter all tokens through conditionals parser, and throw away comments before main parser. Just as OCaml parser.
Should fix #6
