### PR TITLE
Added haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,6 @@
+{
+  "name": "haxeparser",
+  "url": "https://github.com/Simn/haxeparser",
+  "classPath": "src",
+  "contributors": ["Simn"]
+}


### PR DESCRIPTION
Adds haxelib.json so Haxeparser can be used as an Haxe library.