### PR TITLE
This fixes some things but I'm pretty sure it's the wrong way to fix it

### DIFF
--- a/src/haxeparser/HaxeParser.hx
+++ b/src/haxeparser/HaxeParser.hx
@@ -125,8 +125,8 @@ class HaxeTokenSource {
 			switch [tk.tok,state] {
 				case [CommentLine(_) | Comment(_) | Sharp("line"),_]:
 				case [Sharp("error"),_]:
-					tk = condParser.peek(0);
-					switch tk.tok {case Const(CString(_)):tk = lexerToken();case _:}
+					tk = token();
+					switch tk.tok {case Const(CString(_)):tk = token(); case _:}
 				case [Sharp("if"),Consume]:
 					mstack.push(tk.pos);
 					pushSt( enterMacro() ? Consume : SkipBranch );


### PR DESCRIPTION
So, these were failing:

```
#if foo
	#error "bar"
#end

#if foo
	#error
#end
```

Because `condParser.peek(0)` does the same thing as `lexerToken()` (i.e. there's no token buffer). I'm pretty sure this patch is the wrong way to solve it, although I can now parse std.