### PR TITLE
haxelib.json: bump version to 3.3.0

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
   "classPath": "src",
   "license": "BSD",
   "description": "A Haxe parser",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "contributors": ["Simn"],
   "releasenote": "update",
   "dependencies": {


### PR DESCRIPTION
This allows having a version check in haxe-checkstyle to deal with #30 (see also https://github.com/HaxeCheckstyle/haxe-checkstyle/issues/262).

![](http://i.imgur.com/zMC42Ei.png)