### PR TITLE
In is now a binop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ haxe:
   - 3.4.2
   - development
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install mono-devel
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - mono-devel
 
 hxml:
   - build.hxml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: haxe
 
+haxe:
+  - 3.4.2
+  - development
+
 before_install:
   - sudo apt-get update
   - sudo apt-get install mono-devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ haxe:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:

--- a/src/haxeparser/Data.hx
+++ b/src/haxeparser/Data.hx
@@ -30,7 +30,6 @@ enum Keyword {
 	KwdThrow;
 	KwdExtern;
 	KwdEnum;
-	KwdIn;
 	KwdInterface;
 	KwdUntyped;
 	KwdCast;
@@ -77,7 +76,6 @@ class KeywordPrinter {
 			case KwdThrow: "throw";
 			case KwdExtern: "extern";
 			case KwdEnum: "enum";
-			case KwdIn: "in";
 			case KwdInterface: "interface";
 			case KwdUntyped: "untyped";
 			case KwdCast: "cast";

--- a/src/haxeparser/Data.hx
+++ b/src/haxeparser/Data.hx
@@ -30,6 +30,9 @@ enum Keyword {
 	KwdThrow;
 	KwdExtern;
 	KwdEnum;
+	#if (haxe_ver < 4)
+	KwdIn;
+	#end
 	KwdInterface;
 	KwdUntyped;
 	KwdCast;
@@ -76,6 +79,9 @@ class KeywordPrinter {
 			case KwdThrow: "throw";
 			case KwdExtern: "extern";
 			case KwdEnum: "enum";
+			#if (haxe_ver < 4)
+			case KwdIn: "in";
+			#end
 			case KwdInterface: "interface";
 			case KwdUntyped: "untyped";
 			case KwdCast: "cast";

--- a/src/haxeparser/HaxeLexer.hx
+++ b/src/haxeparser/HaxeLexer.hx
@@ -106,6 +106,7 @@ class HaxeLexer extends Lexer implements hxparse.RuleBuilder {
 		"/" => mk(lexer,Binop(OpDiv)),
 		"-" => mk(lexer,Binop(OpSub)),
 		"=" => mk(lexer,Binop(OpAssign)),
+		"in" => mk(lexer,Binop(OpIn)),
 		"[" => mk(lexer, BkOpen),
 		"]" => mk(lexer, BkClose),
 		"{" => mk(lexer, BrOpen),

--- a/src/haxeparser/HaxeLexer.hx
+++ b/src/haxeparser/HaxeLexer.hx
@@ -106,7 +106,9 @@ class HaxeLexer extends Lexer implements hxparse.RuleBuilder {
 		"/" => mk(lexer,Binop(OpDiv)),
 		"-" => mk(lexer,Binop(OpSub)),
 		"=" => mk(lexer,Binop(OpAssign)),
+		#if (haxe_ver >= 4)
 		"in" => mk(lexer,Binop(OpIn)),
+		#end
 		"[" => mk(lexer, BkOpen),
 		"]" => mk(lexer, BkClose),
 		"{" => mk(lexer, BrOpen),

--- a/src/haxeparser/HaxeParser.hx
+++ b/src/haxeparser/HaxeParser.hx
@@ -337,7 +337,9 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 			case OpBoolAnd : {p: 0, left: left};
 			case OpBoolOr : {p: 0, left: left};
 			case OpArrow : {p: 0, left: left};
+			#if (haxe_ver >= 4)
 			case OpIn : {p: 9, left: right};
+			#end
 			case OpAssign | OpAssignOp(_) : {p:10, left:right};
 		}
 	}
@@ -615,7 +617,7 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 						decl: EImport(acc, INormal),
 						pos: p2
 					}
-				case [{tok:Binop(OpIn) | Const(CIdent('as'))}, {tok:Const(CIdent(name))}, {tok:Semicolon, pos:p2}]:
+				case [{tok:#if (haxe_ver < 4) Kwd(KwdIn) #else Binop(OpIn) #end | Const(CIdent('as'))}, {tok:Const(CIdent(name))}, {tok:Semicolon, pos:p2}]:
 					return {
 						decl: EImport(acc, IAsName(name)),
 						pos: p2
@@ -1330,6 +1332,10 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 				makeBinop(op,e1,e2);
 			case [{tok:Question}, e2 = expr(), {tok:DblDot}, e3 = expr()]:
 				{ expr: ETernary(e1,e2,e3), pos: punion(e1.pos, e3.pos)};
+			#if (haxe_ver < 4)
+			case [{tok:Kwd(KwdIn)}, e2 = expr()]:
+				{expr:EIn(e1,e2), pos:punion(e1.pos, e2.pos)};
+			#end
 			case [{tok:Unop(op), pos:p} && isPostfix(e1,op)]:
 				exprNext({expr:EUnop(op,true,e1), pos:punion(e1.pos, p)});
 			case [{tok:BrOpen, pos:p1} && isDollarIdent(e1), eparam = expr(), {tok:BrClose,pos:p2}]:
@@ -1483,7 +1489,9 @@ private class Reificator{
 			case OpAssignOp(o): return mkEnum("Binop", "OpAssignOp", [toBinop(o, p)], p);
 			case OpInterval: return op("OpInterval");
 			case OpArrow: return op("OpArrow");
+			#if (haxe_ver >= 4)
 			case OpIn: return op("OpIn");
+			#end
 		}
 	}
 
@@ -1741,6 +1749,10 @@ private class Reificator{
 				expr("EBlock", [toExprArray(el, p)]);
 			case EFor(e1, e2):
 				expr("EFor", [loop(e1), loop(e2)]);
+			#if (haxe_ver < 4)
+			case EIn(e1, e2):
+				expr("EIn", [loop(e1), loop(e2)]);
+			#end
 			case EIf(e1, e2, eelse):
 				expr("EIf", [loop(e1), loop(e2), toOpt(toExpr, eelse, p)]);
 			case EWhile(e1, e2, normalWhile):

--- a/src/haxeparser/HaxeParser.hx
+++ b/src/haxeparser/HaxeParser.hx
@@ -337,6 +337,7 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 			case OpBoolAnd : {p: 0, left: left};
 			case OpBoolOr : {p: 0, left: left};
 			case OpArrow : {p: 0, left: left};
+			case OpIn : {p: 9, left: right};
 			case OpAssign | OpAssignOp(_) : {p:10, left:right};
 		}
 	}
@@ -614,7 +615,7 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 						decl: EImport(acc, INormal),
 						pos: p2
 					}
-				case [{tok:Kwd(KwdIn) | Const(CIdent('as'))}, {tok:Const(CIdent(name))}, {tok:Semicolon, pos:p2}]:
+				case [{tok:Binop(OpIn) | Const(CIdent('as'))}, {tok:Const(CIdent(name))}, {tok:Semicolon, pos:p2}]:
 					return {
 						decl: EImport(acc, IAsName(name)),
 						pos: p2
@@ -1329,8 +1330,6 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 				makeBinop(op,e1,e2);
 			case [{tok:Question}, e2 = expr(), {tok:DblDot}, e3 = expr()]:
 				{ expr: ETernary(e1,e2,e3), pos: punion(e1.pos, e3.pos)};
-			case [{tok:Kwd(KwdIn)}, e2 = expr()]:
-				{expr:EIn(e1,e2), pos:punion(e1.pos, e2.pos)};
 			case [{tok:Unop(op), pos:p} && isPostfix(e1,op)]:
 				exprNext({expr:EUnop(op,true,e1), pos:punion(e1.pos, p)});
 			case [{tok:BrOpen, pos:p1} && isDollarIdent(e1), eparam = expr(), {tok:BrClose,pos:p2}]:
@@ -1484,6 +1483,7 @@ private class Reificator{
 			case OpAssignOp(o): return mkEnum("Binop", "OpAssignOp", [toBinop(o, p)], p);
 			case OpInterval: return op("OpInterval");
 			case OpArrow: return op("OpArrow");
+			case OpIn: return op("OpIn");
 		}
 	}
 
@@ -1741,8 +1741,6 @@ private class Reificator{
 				expr("EBlock", [toExprArray(el, p)]);
 			case EFor(e1, e2):
 				expr("EFor", [loop(e1), loop(e2)]);
-			case EIn(e1, e2):
-				expr("EIn", [loop(e1), loop(e2)]);
 			case EIf(e1, e2, eelse):
 				expr("EIf", [loop(e1), loop(e2), toOpt(toExpr, eelse, p)]);
 			case EWhile(e1, e2, normalWhile):

--- a/test/DefinitionConverter.hx
+++ b/test/DefinitionConverter.hx
@@ -25,7 +25,8 @@ class DefinitionConverter {
 			pos: null,
 			isExtern: false,
 			kind: TDStructure,
-			fields: []
+			fields: [],
+			doc: null
 		}
 	}
 

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -11,6 +11,7 @@ class Test extends haxe.unit.TestCase {
 		haxe.Timer.measure(function() {
 			r.run();
 		});
+		Sys.exit(r.result.success ? 0 : 1);
 	}
 
 	function testConst() {


### PR DESCRIPTION
Works for all but one test (including a std parse)

```
* Test::testIn()
ERR: Test.hx:185(Test.testIn) - expected 'a in b' but was 'a  in  b'
```

which is `eeq("a in b");` because `new haxe.macro.Printer("").printBinop(OpIn)` gives ` in ` (there is one space before and after in).

No idea how to fix that.
