### PR TITLE
Fix OpIn precedence

### DIFF
--- a/src/haxeparser/HaxeParser.hx
+++ b/src/haxeparser/HaxeParser.hx
@@ -327,20 +327,20 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 		var left = true;
 		var right = false;
 		return switch(op) {
-			case OpMod : {p: 0, left: left};
-			case OpMult | OpDiv : {p: 0, left: left};
-			case OpAdd | OpSub : {p: 0, left: left};
-			case OpShl | OpShr | OpUShr : {p: 0, left: left};
-			case OpOr | OpAnd | OpXor : {p: 0, left: left};
-			case OpEq | OpNotEq | OpGt | OpLt | OpGte | OpLte : {p: 0, left: left};
-			case OpInterval : {p: 0, left: left};
-			case OpBoolAnd : {p: 0, left: left};
-			case OpBoolOr : {p: 0, left: left};
-			case OpArrow : {p: 0, left: left};
 			#if (haxe_ver >= 4)
-			case OpIn : {p: 9, left: right};
+			case OpIn : {p: 0, left: right};
 			#end
-			case OpAssign | OpAssignOp(_) : {p:10, left:right};
+			case OpMod : {p: 1, left: left};
+			case OpMult | OpDiv : {p: 2, left: left};
+			case OpAdd | OpSub : {p: 3, left: left};
+			case OpShl | OpShr | OpUShr : {p: 4, left: left};
+			case OpOr | OpAnd | OpXor : {p: 5, left: left};
+			case OpEq | OpNotEq | OpGt | OpLt | OpGte | OpLte : {p: 6, left: left};
+			case OpInterval : {p: 7, left: left};
+			case OpBoolAnd : {p: 8, left: left};
+			case OpBoolOr : {p: 9, left: left};
+			case OpArrow : {p: 10, left: left};
+			case OpAssign | OpAssignOp(_) : {p:11, left:right};
 		}
 	}
 

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -184,6 +184,30 @@ class Test extends haxe.unit.TestCase {
 
 	function testIn() {
 		eeq("a in b");
+		paeq("a in b in c", "(a in (b in c))");
+		paeq("a % b in c", "(a % (b in c))");
+		paeq("a * b in c", "(a * (b in c))");
+		paeq("a / b in c", "(a / (b in c))");
+		paeq("a + b in c", "(a + (b in c))");
+		paeq("a - b in c", "(a - (b in c))");
+		paeq("a << b in c", "(a << (b in c))");
+		paeq("a >> b in c", "(a >> (b in c))");
+		paeq("a >>> b in c", "(a >>> (b in c))");
+		paeq("a | b in c", "(a | (b in c))");
+		paeq("a & b in c", "(a & (b in c))");
+		paeq("a ^ b in c", "(a ^ (b in c))");
+		paeq("a == b in c", "(a == (b in c))");
+		paeq("a != b in c", "(a != (b in c))");
+		paeq("a > b in c", "(a > (b in c))");
+		paeq("a >= b in c", "(a >= (b in c))");
+		paeq("a < b in c", "(a < (b in c))");
+		paeq("a <= b in c", "(a <= (b in c))");
+		paeq("a...b in c", "(a ... (b in c))");
+		paeq("a || b in c", "(a || (b in c))");
+		paeq("a && b in c", "(a && (b in c))");
+		paeq("a => b in c", "(a => (b in c))");
+		paeq("a = b in c", "(a = (b in c))");
+		paeq("a += b in c", "(a += (b in c))");
 	}
 
 	function testIf() {
@@ -501,5 +525,24 @@ class Test extends haxe.unit.TestCase {
 			expectedCode = inputCode;
 		}
 		assertEquals(whitespaceEreg.replace(expectedCode, ""), whitespaceEreg.replace(inputParsed, ""), p);
+	}
+
+	function parentize(e:haxe.macro.Expr) {
+		return switch e.expr {
+			case EConst(_): e;
+			case _:
+				e = haxe.macro.ExprTools.map(e, parentize);
+				{expr: haxe.macro.Expr.ExprDef.EParenthesis(e), pos: e.pos};
+		}
+	}
+
+	function paeq(inputCode:String, ?expectedCode:String, ?p:haxe.PosInfos) {
+		var parser = new haxeparser.HaxeParser(byte.ByteData.ofString(inputCode), '${p.methodName}:${p.lineNumber}');
+		var expr = parser.expr();
+		var printer = new haxe.macro.Printer();
+		if (expectedCode == null) {
+			expectedCode = inputCode;
+		}
+		assertEquals(printer.printExpr(parentize(expr)), expectedCode, p);
 	}
 }


### PR DESCRIPTION
Took @nadako tests from https://github.com/HaxeFoundation/haxe/commit/f947076ab2b89f0e9d4777352ee99d35fc2a331b
and modified the precedence values to those of parser.mly

Didn't have a lot of ideas for the function name, hope `paeq` isn't too bad :D