### PR TITLE
support multiline string interpolation

### DIFF
--- a/src/haxeparser/HaxeLexer.hx
+++ b/src/haxeparser/HaxeLexer.hx
@@ -241,6 +241,10 @@ class HaxeLexer extends Lexer implements hxparse.RuleBuilder {
 		"[^/\"'{}\n\r]+" => {
 			buf.add(lexer.current);
 			lexer.token(codeString);
+		},
+		"[\r\n\t ]+" => {
+			buf.add(lexer.current);
+			lexer.token(codeString);
 		}
 	];
 

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -481,6 +481,10 @@ class Test extends haxe.unit.TestCase {
 		peq("class C { static function main() '{${printClassRec(c,'',s)}}';}", "class C {static function main() \"{${printClassRec(c,\\'\\',s)}}\";}");
 	}
 
+	function testMultilineStringInterpolation() {
+		peq("class C { static function main() '{${\nprintClassRec(c,'',s)\n}}';}", "class C {static function main() \"{${\nprintClassRec(c,\\'\\',s)\n}}\";}");
+	}
+
 	static function parseExpr(inputCode:String, ?p:haxe.PosInfos) {
 		var parser = new haxeparser.HaxeParser(byte.ByteData.ofString(inputCode), '${p.methodName}:${p.lineNumber}');
 		var expr = parser.expr();


### PR DESCRIPTION
fixes an issue with string interpolation spanning multiple lines from: 
https://github.com/HaxeCheckstyle/haxe-formatter/issues/261 and https://github.com/HaxeCheckstyle/haxe-formatter/issues/203

I've added a testcase, but tests don't run with neither Haxe 3.4.7 nor Haxe 4 preview 5, so I'm not sure if it works.