### PR TITLE
added isFinal field to Var structure

### DIFF
--- a/src/haxeparser/HaxeParser.hx
+++ b/src/haxeparser/HaxeParser.hx
@@ -1124,8 +1124,8 @@ class HaxeParser extends hxparse.Parser<HaxeTokenSource, Token> implements hxpar
 		return switch stream {
 			case [id = dollarIdent(), t = parseTypeOpt()]:
 				switch stream {
-					case [{tok:Binop(OpAssign)}, e = expr()]: { name: id.name, type: t, expr: e};
-					case _: { name: id.name, type:t, expr: null};
+					case [{tok:Binop(OpAssign)}, e = expr()]: { name: id.name, type: t, expr: e, isFinal: false};
+					case _: { name: id.name, type:t, expr: null, isFinal: false};
 				}
 		}
 	}


### PR DESCRIPTION
Apparently `isFinal` field is needed to make checkstyle compile with Haxe 4.

I couldn't come up with a full implementation for `final`, so it's just a bugfix to make checkstyle work.